### PR TITLE
Add branch protection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.0 (2019-03-15)
+
+### Features
+
+* add `branch_protection ` support.
+
 # [1.4.0] (2019-03-13)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ module "repository" {
 | `teams` | `list` | Add the repository to a team or update teams permission on the repository. |
 | `deploy_keys` | `list` | Add deploy keys (SSH keys) that grants access to the repository. |
 
+If enabled, `branch_protection` adds the the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+|`branch_protection_enabled`|`string`|Enable branch protection for the default branch|
+|`branch_protection_enforce_admins`|`string`|Setting this to true enforces status checks for repository administrators. Default: `false`|
+|`branch_protection_strict`|`string`|Require branches to be up to date before merging. Default: `true`|
+|`branch_protection_contexts`|`list`|The list of status checks to require in order to merge into this branch. Default: `[]`|
+|`branch_protection_dismiss_stale_reviews`|`string`|Dismiss approved reviews automatically when a new commit is pushed. Default: `true`.|
+|`branch_protection_dismissal_users`|`list`|The list of user logins with dismissal access. Default: `[]`|
+|`branch_protection_dismissal_teams`|`list`|The list of team slugs with dismissal access. Always use slug of the team, not its name. Each team already has to have access to the repository. Default: `[]`|
+|`branch_protection_require_code_owner_reviews`|`string`|Require an approved review in pull requests including files with a designated code owner. Default: `false`|
+|`branch_protection_restrictions_users`|`list`|The list of user logins with push access. Default: `[]`|
+|`branch_protection_restrictions_teams`|`list`|The list of team slugs with push access. Always use slug of the team, not its name. Each team already has to have access to the repository. Default: `[]`|
+
+Note that`branch_protection` only applies to the default branch of the repository.
+
 The `collaborators` object must have the following keys:
 
 | Name | Type | Description |

--- a/examples/example-branch_protection.tf
+++ b/examples/example-branch_protection.tf
@@ -1,0 +1,27 @@
+module "repository_bp" {
+  source = "../"
+
+  name               = "example"
+  description        = "My example codebase"
+  private            = false
+  gitignore_template = "Node"
+  license_template   = "mit"
+  topics             = ["example"]
+
+  issue_labels = [{
+    name        = "kind/bug"
+    color       = "D73A4A"
+    description = "Something isn't working"
+  }]
+
+  branch_protection_enabled                    = 1
+  branch_protection_enforce_admins             = true
+  branch_protection_strict                     = true
+  branch_protection_contexts                   = ["ci/travis"]
+  branch_protection_dismiss_stale_reviews      = true
+  branch_protection_dismissal_users            = []
+  branch_protection_dismissal_teams            = []
+  branch_protection_require_code_owner_reviews = false
+  branch_protection_restrictions_users         = []
+  branch_protection_restrictions_teams         = []
+}

--- a/examples/example-labels.tf
+++ b/examples/example-labels.tf
@@ -1,4 +1,4 @@
-module "repository" {
+module "repository_labels" {
   source = "../"
 
   name               = "example"

--- a/main.tf
+++ b/main.tf
@@ -62,3 +62,29 @@ resource "github_issue_label" "main" {
   color       = "${lookup(var.issue_labels[count.index], "color")}"
   description = "${lookup(var.issue_labels[count.index], "description", "")}"
 }
+
+resource "github_branch_protection" "main" {
+  # Hack from https://github.com/hashicorp/terraform/issues/2831#issuecomment-124163153
+  count = "${var.branch_protection_enabled ? 1 : 0}"
+
+  repository     = "${github_repository.main.name}"
+  branch         = "${github_repository.main.default_branch}"
+  enforce_admins = "${var.branch_protection_enforce_admins}"
+
+  required_status_checks {
+    strict   = "${var.branch_protection_strict}"
+    contexts = "${var.branch_protection_contexts}"
+  }
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews      = "${var.branch_protection_dismiss_stale_reviews}"
+    dismissal_users            = "${var.branch_protection_dismissal_users}"
+    dismissal_teams            = "${var.branch_protection_dismissal_teams}"
+    require_code_owner_reviews = "${var.branch_protection_require_code_owner_reviews}"
+  }
+
+  restrictions {
+    users = "${var.branch_protection_restrictions_users}"
+    teams = "${var.branch_protection_restrictions_teams}"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -151,5 +151,65 @@ variable "deploy_keys" {
 variable "issue_labels" {
   type        = "list"
   default     = []
-  description = "Create and manage issue labels for a repository"
+  description = "Create and manage issue labels for a repository."
+}
+
+variable "branch_protection_enabled" {
+  type        = "string"
+  default     = 1
+  description = "Enable branch protection."
+}
+
+variable "branch_protection_enforce_admins" {
+  type        = "string"
+  default     = false
+  description = "Enforce status checks for repository administrators."
+}
+
+variable "branch_protection_strict" {
+  type        = "string"
+  default     = true
+  description = "Require branches to be up to date before merging."
+}
+
+variable "branch_protection_contexts" {
+  type        = "list"
+  default     = []
+  description = "The list of status checks to require in order to merge into this branch."
+}
+
+variable "branch_protection_dismiss_stale_reviews" {
+  type        = "string"
+  default     = true
+  description = "Dismiss approved reviews automatically when a new commit is pushed."
+}
+
+variable "branch_protection_dismissal_users" {
+  type        = "list"
+  default     = []
+  description = "The list of user logins with dismissal access."
+}
+
+variable "branch_protection_dismissal_teams" {
+  type        = "list"
+  default     = []
+  description = "The list of team slugs with dismissal access."
+}
+
+variable "branch_protection_require_code_owner_reviews" {
+  type        = "string"
+  default     = false
+  description = "Require an approved review in pull requests including files with a designated code owner."
+}
+
+variable "branch_protection_restrictions_users" {
+  type        = "list"
+  default     = []
+  description = "The list of user logins with push access."
+}
+
+variable "branch_protection_restrictions_teams" {
+  type        = "list"
+  default     = []
+  description = "The list of team slugs with push access."
 }


### PR DESCRIPTION
Adds the option to enable branch protection to the default branch of a
repository.

Due to current HCL limitations it is not possible to define several
branch protections.

Fixes innovationnorway/terraform-github-repository#7