### PR TITLE
Move all examples in dedicated folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,79 +4,12 @@ Create a new repository.
 
 ## Example Usage
 
-### Create public (e.g. open source) repository
+The [examples](examples) folder contains various examples showcasing various usages of this modules:
 
-```hcl
-module "repository" {
-  source = "innovationnorway/repository/github"
-
-  name = "example"
-
-  description = "My example codebase"
-
-  private = false
-
-  gitignore_template = "Node"
-  license_template   = "mit"
-
-  topics = ["example"]
-}
-```
-
-### Add collaborators and teams
-
-```hcl
-module "repository" {
-  source = "innovationnorway/repository/github"
-
-  name = "example"
-
-  description = "My example codebase"
-
-  collaborators = [
-    {
-      username   = "joakimhellum-in"
-      permission = "push"
-    },
-    {
-      username   = "innovationnorway-bot"
-      permission = "pull"
-    },
-  ]
-
-  teams = [
-    {
-      name       = "terraform"
-      permission = "push"
-    },
-    {
-      name       = "security"
-      permission = "pull"
-    },
-  ]
-}
-```
-
-### Add deploy keys
-
-```hcl
-module "repository" {
-  source = "innovationnorway/repository/github"
-
-  name = "example"
-
-  description = "My example codebase"
-
-  deploy_keys = [
-    {
-      title = "example-key"
-      key   = "ssh-rsa AAAAB3NzaC1yc2EAAA..."
-
-      read_only = true
-    },
-  ]
-}
-```
+* [Create public (e.g. open source) repository](examples/example-simple.tf)
+* [Add collaborators and teams](examples/example-collaborators_and_teams.tf)
+* [Add deploy keys](examples/example-deploy_keys.tf)
+* [Add issue labels](examples/example-labels.tf)
 
 ## Arguments
 

--- a/examples/example-collaborators_and_teams.tf
+++ b/examples/example-collaborators_and_teams.tf
@@ -1,0 +1,29 @@
+module "repository_collaborators" {
+  source = "../"
+
+  name = "example"
+
+  description = "My example codebase"
+
+  collaborators = [
+    {
+      username   = "joakimhellum-in"
+      permission = "push"
+    },
+    {
+      username   = "innovationnorway-bot"
+      permission = "pull"
+    },
+  ]
+
+  teams = [
+    {
+      name       = "terraform"
+      permission = "push"
+    },
+    {
+      name       = "security"
+      permission = "pull"
+    },
+  ]
+}

--- a/examples/example-deploy_keys.tf
+++ b/examples/example-deploy_keys.tf
@@ -1,0 +1,16 @@
+module "repository_deploy_keys" {
+  source = "../"
+
+  name = "example"
+
+  description = "My example codebase"
+
+  deploy_keys = [
+    {
+      title = "example-key"
+      key   = "ssh-rsa AAAAB3NzaC1yc2EAAA..."
+
+      read_only = true
+    },
+  ]
+}

--- a/examples/example-simple.tf
+++ b/examples/example-simple.tf
@@ -1,0 +1,14 @@
+module "repository_simple" {
+  source = "../"
+
+  name = "example"
+
+  description = "My example codebase"
+
+  private = false
+
+  gitignore_template = "Node"
+  license_template   = "mit"
+
+  topics = ["example"]
+}


### PR DESCRIPTION
Moves all the examples to a dedicated folder in order to de-clutter the
README as well as providing another cheap way of testing the module.

I wanted to test using the following command:

```bash
cd examples && rm -fr ./terraform && terraform init && terraform plan
```

But it errored out as the teams were missing. Maybe you could create "fake" teams to allow us to test the example cheaply/quickly?